### PR TITLE
File tree list

### DIFF
--- a/src/EditorTab.jl
+++ b/src/EditorTab.jl
@@ -269,7 +269,7 @@ function editor_autocomplete(view::GtkTextView,t::EditorTab,replace=true)
     return convert(Cint, true)
 end
 
-function tuple_autocomplete(it::GtkTextIter,buffer::GtkTextBuffer,completion_window::CompletionWindow,view::GtkTextView)
+function tuple_autocomplete(it::GtkTextIter, buffer::GtkTextBuffer, completion_window::CompletionWindow, view::GtkTextView)
 
     (found,tu,itstart) = select_tuple(it, buffer)
     !found && return PROPAGATE

--- a/src/FilesPanel.jl
+++ b/src/FilesPanel.jl
@@ -274,7 +274,7 @@ end
     touch(filename)
     update!(filespanel.list, filename, iterator)
     open_in_new_tab(filename)
-    hide(filespanel.path_dialog.dialog)
+    visible(filespanel.path_dialog.dialog,false)
 
     return nothing
 end
@@ -286,7 +286,7 @@ function path_dialog_create_directory_cb(ptr::Ptr, data)
     filename = getproperty(te_filename, :text, AbstractString)
     mkdir(filename)
     update!(filespanel.list,filename,iterator)
-    hide(filespanel.path_dialog.dialog)
+    visible(filespanel.path_dialog.dialog,false)
     return nothing
 end
 
@@ -300,7 +300,7 @@ end
     update!(filespanel.list, filename,copy_up(GtkTreeModel(filespanel.list),filespanel.current_iterator))
     delete!(filespanel.list, filespanel.current_iterator)
 
-    hide(filespanel.path_dialog.dialog)
+    visible(filespanel.path_dialog.dialog,false)
 
     return nothing
 end

--- a/src/FilesPanel.jl
+++ b/src/FilesPanel.jl
@@ -367,8 +367,8 @@ function configure(dialog::FilePathDialog,
     if (dialog.signal_delete_id > 0)
         signal_handler_disconnect(te,dialog.signal_delete_id)
     end
-    if (!endswith(path,'/'))
-        path = string(path,'/')
+    if (!isdirpath(path))
+	    path = joinpath(path,"")        
     end
     (dialog.signal_insert_id, dialog.signal_delete_id) = configure_text_entry_fixed_content(te_filename,path,filename)
 
@@ -398,7 +398,7 @@ function filespanel_treeview_row_expanded_cb(treeviewptr::Ptr,
 end
 
 
-function filespanel_treeview_clicked_cb(widgetptr::Ptr, eventptr::Ptr, filespanel)
+@guarded (PROPAGATE) function filespanel_treeview_clicked_cb(widgetptr::Ptr, eventptr::Ptr, filespanel)
     treeview = convert(GtkTreeView, widgetptr)
     event = convert(Gtk.GdkEvent, eventptr)
     list = filespanel.list

--- a/src/FilesPanel.jl
+++ b/src/FilesPanel.jl
@@ -21,6 +21,17 @@ function files_tree_view(rownames)
     push!(tv,c2)
     return (tv,list,cols)
 end
+type FilePathDialog
+  dialog::GtkDialog
+  signal_insert_id::Culong
+  signal_delete_id::Culong
+end
+function FilePathDialog()
+    w = GAccessor.object(form_builder,"DialogCreateFile")
+    Gtk.GAccessor.transient_for(w,win)
+    Gtk.GAccessor.modal(w,true)
+    return FilePathDialog(w,0,0)
+end
 
 type FilesPanel <: GtkScrolledWindow
     handle::Ptr{Gtk.GObject}
@@ -29,14 +40,14 @@ type FilesPanel <: GtkScrolledWindow
     paste_action
     menu
     current_iterator
-    dialog
+    path_dialog::FilePathDialog
 
     function FilesPanel()
         sc = @GtkScrolledWindow()
         (tv,list,cols) = files_tree_view(["Icon","Name"])
         push!(sc,tv)
 
-        t = new(sc.handle,list,tv,nothing,nothing,nothing,nothing);
+        t = new(sc.handle,list,tv,nothing,nothing,nothing,FilePathDialog());
         t.menu = filespanel_context_menu_create(t)
 
         signal_connect(filespanel_treeview_clicked_cb,tv, "button-press-event",
@@ -49,7 +60,7 @@ type FilesPanel <: GtkScrolledWindow
     end
 end
 function filespanel_context_menu_create(t::FilesPanel)
-    menu = @GtkMenu(file) |>
+    menu = @GtkMenu() |>
     (changeDirectoryItem = @GtkMenuItem("Change Directory")) |>
     (addToPathItem = @GtkMenuItem("Add to Path")) |>
     @GtkSeparatorMenuItem() |>
@@ -167,9 +178,18 @@ function get_selected_file(treeview::GtkTreeView,list::GtkTreeStore)
         return nothing
     end
 end
+function file_already_opened(filename)
+    for i=1:length(editor)
+        t = get_tab(editor,i)
+        if typeof(t) == EditorTab && t.filename == filename #in case we want to have something else in the editor
+            return true
+        end
+    end
+    return false
+end
 function open_file(treeview::GtkTreeView,list::GtkTreeStore)
     file = get_selected_file(treeview,list)
-    if file != nothing
+    if file != nothing && !file_already_opened(file)
         open_in_new_tab(file)
     end
 end
@@ -181,8 +201,8 @@ function path_dialog_create_file_cb(ptr::Ptr, data)
     touch(filename)
     add_file(filespanel.list, dirname(filename), basename(filename), filespanel.current_iterator)
     open_in_new_tab(filename)
-    destroy(filespanel.dialog)
-    filespanel.dialog=nothing
+    hide(filespanel.path_dialog.dialog)
+
     return nothing
 end
 function path_dialog_create_directory_cb(ptr::Ptr, data)
@@ -191,8 +211,8 @@ function path_dialog_create_directory_cb(ptr::Ptr, data)
     filename = getproperty(te_filename, :text, AbstractString)
     mkdir(filename)
     add_folder(filespanel.list,filename,filespanel.current_iterator)
-    destroy(filespanel.dialog)
-    filespanel.dialog=nothing
+    hide(filespanel.path_dialog.dialog)
+
     return nothing
 end
 function path_dialog_rename_file_cb(ptr::Ptr,  data)
@@ -206,12 +226,12 @@ function path_dialog_rename_file_cb(ptr::Ptr,  data)
     #      of every child of the element renamed
     delete!(filespanel.list, filespanel.current_iterator)
     update!(filespanel.list, destination,filespanel.current_iterator)
-    destroy(filespanel.dialog)
-    filespanel.dialog=nothing
+    hide(filespanel.path_dialog.dialog)
+
     return nothing
 end
 function path_dialog_filename_inserted_text(text_entry_buffer_ptr::Ptr,
-                                            ursor_pos,
+                                            cursor_pos,
                                             new_text::Cstring,
                                             n_chars,
                                             data)
@@ -219,9 +239,9 @@ function path_dialog_filename_inserted_text(text_entry_buffer_ptr::Ptr,
     delete_signal_id  = data[2]
     text_entry_buffer = convert(GtkEntryBuffer, text_entry_buffer_ptr)
     if (cursor_pos < length(path))
-        Gtk.signal_handler_block(text_entry_buffer, delete_signal_id[])
+        Gtk.signal_handler_block(text_entry_buffer, delete_signal_id)
         delete_text(text_entry_buffer,cursor_pos,n_chars)
-        Gtk.signal_handler_unblock(text_entry_buffer, delete_signal_id[])
+        Gtk.signal_handler_unblock(text_entry_buffer, delete_signal_id)
     end
     return nothing
 end
@@ -230,46 +250,57 @@ function path_dialog_filename_deleted_text(text_entry_buffer_ptr::Ptr, cursor_po
     insert_signal_id = data[2]
     text_entry_buffer = convert(GtkEntryBuffer, text_entry_buffer_ptr)
     if (cursor_pos < length(path))
-        Gtk.signal_handler_block(text_entry_buffer, insert_signal_id[])
+        Gtk.signal_handler_block(text_entry_buffer, insert_signal_id)
         insert_text(text_entry_buffer,
                     cursor_pos,
                     path[cursor_pos+1:min(end,cursor_pos+n_chars+1)],
                     n_chars)
-        Gtk.signal_handler_unblock(text_entry_buffer, insert_signal_id[])
+        Gtk.signal_handler_unblock(text_entry_buffer, insert_signal_id)
     end
     return nothing
 end
+
 function configure_text_entry_fixed_content(te, fixed, nonfixed="")
+    setproperty!(te, :text,"");
     setproperty!(te, :text,string(fixed,nonfixed));
     te = buffer(te)
-    const id_signal_insert = [Culong(0)]
-    const id_signal_delete = [Culong(0)]
-    id_signal_insert[1] = signal_connect(path_dialog_filename_inserted_text,
+    id_signal_insert = Culong(0)
+    id_signal_delete = Culong(0)
+    id_signal_insert = signal_connect(path_dialog_filename_inserted_text,
         te,
         "inserted-text",
         Void,
         (Cuint,Cstring,Cuint),false,(fixed,id_signal_delete))
-    id_signal_delete[1] = signal_connect(path_dialog_filename_deleted_text,
+    id_signal_delete = signal_connect(path_dialog_filename_deleted_text,
         te,
         "deleted-text",
         Void,
         (Cuint,Cuint),false,(fixed,id_signal_insert))
+    return (id_signal_insert, id_signal_delete)
 end
-function file_path_dialog_create(action::Function,
-                                 files_panel::FilesPanel,
-                                 path::AbstractString,
-                                 filename::AbstractString="",
-                                 params=()  )
-    w = GAccessor.object(form_builder,"DialogCreateFile")
+function configure(dialog::FilePathDialog,
+                   action::Function,
+                   files_panel::FilesPanel,
+                   path::AbstractString,
+                   filename::AbstractString="",
+                   params=())
+  #Disconnect the Text Entry
     te_filename = GAccessor.object(form_builder,"filename")
+    te = buffer(te_filename)
+    if (dialog.signal_insert_id > 0)
+        signal_handler_disconnect(te,dialog.signal_insert_id)
+    end
+    if (dialog.signal_delete_id > 0)
+        signal_handler_disconnect(te,dialog.signal_delete_id)
+    end
     if (!endswith(path,'/'))
         path = string(path,'/')
     end
-    configure_text_entry_fixed_content(te_filename,path,filename)
+    (dialog.signal_insert_id, dialog.signal_delete_id) = configure_text_entry_fixed_content(te_filename,path,filename)
     btn_create_file = GAccessor.object(form_builder,"btnCreateFile")
     signal_connect(action,btn_create_file, "clicked",Void,(),false,tuple((te_filename,files_panel)...,params...))
-    return w
 end
+
 function file_path_dialog_set_button_caption(w, caption::AbstractString)
     btn_create_file = GAccessor.object(form_builder,"btnCreateFile")
     setproperty!(btn_create_file,:label,caption)
@@ -292,7 +323,7 @@ function filespanel_treeview_row_expanded_cb(treeviewptr::Ptr,
     return Cint(0)
 end
 
-function filespanel_treeview_clicked_cb(widgetptr::Ptr, eventptr::Ptr, filespanel)
+@guarded PROPAGATE function filespanel_treeview_clicked_cb(widgetptr::Ptr, eventptr::Ptr, filespanel)
     treeview = convert(GtkTreeView, widgetptr)
     event = convert(Gtk.GdkEvent, eventptr)
     list = filespanel.list
@@ -325,17 +356,21 @@ function filespanel_treeview_keypress_cb(widgetptr::Ptr, eventptr::Ptr, filespan
     return PROPAGATE
 end
 
-function filespanel_newFileItem_activate_cb(widgetptr::Ptr,filespanel)
-    if (filespanel.current_iterator!=nothing)
+ @guarded nothing function filespanel_newFileItem_activate_cb(widgetptr::Ptr,filespanel)
+    if (filespanel.current_iterator != nothing)
         current_path =  Gtk.getindex(filespanel.list,filespanel.current_iterator,3)
         if isfile(current_path)
             current_path = dirname(current_path)
         end
-        filespanel.dialog = file_path_dialog_create(path_dialog_create_file_cb,
-                                                    filespanel,
-                                                    current_path )
-        file_path_dialog_set_button_caption(filespanel.dialog,"+")
-        showall(filespanel.dialog)
+        configure(filespanel.path_dialog ,
+                  path_dialog_create_file_cb,
+                  filespanel,
+                  current_path )
+
+
+        file_path_dialog_set_button_caption(filespanel.path_dialog,"+")
+
+        run(filespanel.path_dialog.dialog)
     end
     return nothing
 end
@@ -348,18 +383,18 @@ function filespanel_deleteItem_activate_cb(widgetptr::Ptr,filespanel)
     end
     return nothing
 end
-function filespanel_renameItem_activate_cb(widgetptr::Ptr,filespanel)
+ function filespanel_renameItem_activate_cb(widgetptr::Ptr,filespanel)
     if (filespanel.current_iterator!=nothing)
         current_path =  Gtk.getindex(filespanel.list,filespanel.current_iterator,3)
         base_path = dirname(current_path)
         resource  = current_path[length(base_path)+2:end]
         #TODO check overwrite
-        filespanel.dialog = file_path_dialog_create(path_dialog_rename_file_cb,
-                                                    filespanel,
-                                                    base_path,
-                                                    resource)
-        file_path_dialog_set_button_caption(filespanel.dialog,"Rename it")
-        showall(filespanel.dialog)
+        configure(filespanel.path_dialog ,
+                  path_dialog_create_file_cb,
+                  filespanel,
+                  current_path )
+        file_path_dialog_set_button_caption(filespanel.path_dialog,"Rename it")
+        run(filespanel.path_dialog.dialog)
     end
     return nothing
 end
@@ -398,11 +433,12 @@ function filespanel_newFolderItem_activate_cb(widgetptr::Ptr,filespanel)
         if isfile(current_path)
             current_path = dirname(current_path)
         end
-        filespanel.dialog = file_path_dialog_create(path_dialog_create_directory_cb,
-                                                    filespanel,
-                                                    current_path )
-        file_path_dialog_set_button_caption(filespanel.dialog,"+")
-        showall(filespanel.dialog)
+        configure(filespanel.path_dialog ,
+                  path_dialog_create_file_cb,
+                  filespanel,
+                  current_path )
+        file_path_dialog_set_button_caption(filespanel.path_dialog,"+")
+        run(filespanel.path_dialog.dialog)
     end
     return nothing
 end

--- a/src/FilesPanel.jl
+++ b/src/FilesPanel.jl
@@ -28,13 +28,19 @@ type FilePathDialog
   signal_delete_id::Culong
   btn_create_file_signal::Culong
 end
+
 function FilePathDialog()
     w = GAccessor.object(form_builder,"DialogCreateFile")
     Gtk.GAccessor.transient_for(w,win)
     Gtk.GAccessor.modal(w,true)
+    btn_create_file = GAccessor.object(form_builder,"btnCreateFile")
+    signal_connect(close_file_path_dialog,btn_create_file, "clicked", Void, (), false,w)
     return FilePathDialog(w,0,0,0)
 end
-
+@guarded nothing function close_file_path_dialog(btn::Ptr,dialog)
+    response(dialog,Gtk.GConstants.GtkResponseType.ACCEPT)
+    return nothing
+end
 type FilesPanel <: GtkScrolledWindow
     handle::Ptr{Gtk.GObject}
     list::GtkTreeStore
@@ -265,34 +271,29 @@ function nearest_folder_from_current_iterator(filespanel)
     return iterator
 end
 #=File path menu =#
-@guarded nothing function path_dialog_create_file_cb(ptr::Ptr, data)
-    (te_filename, filespanel) = data
+ function path_dialog_create_file(filespanel)
+    te_filename = GAccessor.object(form_builder,"filename")
     #TODO check overwrite
-
     iterator = nearest_folder_from_current_iterator(filespanel)
     filename = getproperty(te_filename, :text, AbstractString)
     touch(filename)
     update!(filespanel.list, filename, iterator)
     open_in_new_tab(filename)
-    visible(filespanel.path_dialog.dialog,false)
-
-    return nothing
 end
-function path_dialog_create_directory_cb(ptr::Ptr, data)
-    (te_filename, filespanel) = data
-
+function path_dialog_create_directory(filespanel)
+    te_filename = GAccessor.object(form_builder,"filename")
     iterator = nearest_folder_from_current_iterator(filespanel)
     #TODO check overwrite
     filename = getproperty(te_filename, :text, AbstractString)
     mkdir(filename)
     update!(filespanel.list,filename,iterator)
-    visible(filespanel.path_dialog.dialog,false)
     return nothing
 end
 
-@guarded nothing function path_dialog_rename_file_cb(ptr::Ptr,  data)
+function path_dialog_rename_file(filespanel)
+    te_filename = GAccessor.object(form_builder,"filename")
     #TODO check overwrite
-    (te_filename, filespanel) = data
+
     current_path =  Gtk.getindex(filespanel.list,filespanel.current_iterator,3)
     filename = getproperty(te_filename, :text, AbstractString)
     mv(current_path,filename)
@@ -300,7 +301,7 @@ end
     update!(filespanel.list, filename,copy_up(GtkTreeModel(filespanel.list),filespanel.current_iterator))
     delete!(filespanel.list, filespanel.current_iterator)
 
-    visible(filespanel.path_dialog.dialog,false)
+
 
     return nothing
 end
@@ -353,14 +354,12 @@ function configure_text_entry_fixed_content(te, fixed, nonfixed="")
     return (id_signal_insert, id_signal_delete)
 end
 function configure(dialog::FilePathDialog,
-                   action::Function,
                    files_panel::FilesPanel,
                    path::AbstractString,
-                   filename::AbstractString="",
-                   params=())
+                   filename::AbstractString="")
     #Disconnect the Text Entry
     te_filename = GAccessor.object(form_builder,"filename")
-    btn_create_file = GAccessor.object(form_builder,"btnCreateFile")
+
     te = buffer(te_filename)
     if (dialog.signal_insert_id > 0)
         signal_handler_disconnect(te,dialog.signal_insert_id)
@@ -368,17 +367,12 @@ function configure(dialog::FilePathDialog,
     if (dialog.signal_delete_id > 0)
         signal_handler_disconnect(te,dialog.signal_delete_id)
     end
-    if (dialog.btn_create_file_signal > 0)
-        signal_handler_disconnect(btn_create_file,dialog.btn_create_file_signal)
-    end
     if (!endswith(path,'/'))
         path = string(path,'/')
     end
     (dialog.signal_insert_id, dialog.signal_delete_id) = configure_text_entry_fixed_content(te_filename,path,filename)
 
-    dialog.btn_create_file_signal = signal_connect(action,btn_create_file, "clicked",
-                   Void, (),false,
-                   tuple((te_filename,files_panel)...,params...))
+
 end
 
 function file_path_dialog_set_button_caption(w, caption::AbstractString)
@@ -444,14 +438,18 @@ function filespanel_newFileItem_activate_cb(widgetptr::Ptr,filespanel)
             current_path = dirname(current_path)
         end
         configure(filespanel.path_dialog ,
-                  path_dialog_create_file_cb,
                   filespanel,
                   current_path )
 
 
         file_path_dialog_set_button_caption(filespanel.path_dialog,"+")
 
-        run(filespanel.path_dialog.dialog)
+        ret = run(filespanel.path_dialog.dialog)
+        visible(filespanel.path_dialog.dialog,false)
+        if ret == Gtk.GConstants.GtkResponseType.ACCEPT
+            path_dialog_create_file(filespanel)
+        end
+
     end
     return nothing
 end
@@ -471,12 +469,16 @@ end
         resource  = basename(current_path)
         #TODO check overwrite
         configure(filespanel.path_dialog ,
-                  path_dialog_rename_file_cb,
                   filespanel,
                   base_path,
                   resource )
+
         file_path_dialog_set_button_caption(filespanel.path_dialog,"Rename it")
-        run(filespanel.path_dialog.dialog)
+        ret = run(filespanel.path_dialog.dialog)
+        visible(filespanel.path_dialog.dialog,false)
+        if ret == Gtk.GConstants.GtkResponseType.ACCEPT
+            path_dialog_rename_file(filespanel)
+        end
     end
     return nothing
 end
@@ -516,11 +518,16 @@ function filespanel_newFolderItem_activate_cb(widgetptr::Ptr,filespanel)
             current_path = dirname(current_path)
         end
         configure(filespanel.path_dialog ,
-                  path_dialog_create_directory_cb,
                   filespanel,
                   current_path )
+
         file_path_dialog_set_button_caption(filespanel.path_dialog,"+")
-        run(filespanel.path_dialog.dialog)
+        ret = run(filespanel.path_dialog.dialog)
+        visible(filespanel.path_dialog.dialog,false)
+        if ret ==Gtk.GConstants.GtkResponseType.ACCEPT
+            path_dialog_create_directory(filespanel)
+        end
+
     end
     return nothing
 end

--- a/src/GtkExtensions.jl
+++ b/src/GtkExtensions.jl
@@ -202,22 +202,11 @@ get_tab(notebook::Gtk.GtkNotebook,page_num::Int) = convert(Gtk.GtkWidget,ccall((
 
 set_tab_label_text(notebook::Gtk.GtkNotebook,child,tab_text) = ccall((:gtk_notebook_set_tab_label_text,Gtk.libgtk),Void,(Ptr{Gtk.GObject},
 Ptr{Gtk.GObject},Ptr{UInt8}),notebook,child,tab_text)
-popup_disble(notebook::Gtk.GtkNotebook) = ccall((:gtk_notebook_popup_disable ,Gtk.libgtk),
-      Void,
-      (Ptr{Gtk.GObject},),
-      notebook)
 function tab_num(notebook::Gtk.GtkNotebook,widget)
     return ccall((:gtk_notebook_page_num,Gtk.libgtk),
           Cint,
           (Ptr{Gtk.GObject},Ptr{Gtk.GObject}),
           notebook,widget) +1
-end
-import Base.insert!
-function insert!(w::Gtk.GtkNotebook, position::Integer, x::Union{Gtk.GtkWidget,Gtk.AbstractStringLike}, label::Union{Gtk.GtkWidget,Gtk.AbstractStringLike}, menu::Gtk.GtkWidget)
-    ccall((:gtk_notebook_insert_page_menu,libgtk), Cint,
-        (Ptr{GObject}, Ptr{Gtk.GObject}, Ptr{Gtk.GObject},Ptr{Gtk.GObject}, Cint),
-        w, x, label, menu,position-1)+1
-    w
 end
 
 ## entry
@@ -378,9 +367,6 @@ function model(tree_view::Gtk.GtkTreeView)
                   (Ptr{Gtk.GObject},),
                   tree_view))
 end
-#GtkEventBox
-Gtk.@gtktype GtkEventBox
-GtkEventBoxLeaf() =  GtkEventBoxLeaf(ccall((:gtk_event_box_new ,libgtk), Ptr{GObject},
-        ()))
+
 
 #end#module

--- a/src/GtkExtensions.jl
+++ b/src/GtkExtensions.jl
@@ -359,6 +359,20 @@ function insert(store::GtkTreeStore, it::GtkTreeIter, parent::GtkTreeIter, pos::
     ccall((:gtk_tree_store_insert, Gtk.libgtk), Void,  (Ptr{Gtk.GObject},Ptr{Gtk.GtkTreeIter},Ptr{Gtk.GtkTreeIter},Cint),
             store,it,parent,pos)
 end
+## update iter pointing to nth child n in 1:nchildren)
+## return boolean
+function iter_nth_child(treeModel::Gtk.GtkTreeModel, iter::Gtk.Mutable{Gtk.GtkTreeIter}, piter, n::Int)
+  if (piter==nothing)
+    ret = ccall((:gtk_tree_model_iter_nth_child, Gtk.libgtk), Cint,
+        (Ptr{Gtk.GObject}, Ptr{GtkTreeIter}, Ptr{Gtk.GtkTreeIter}, Cint),
+        treeModel, iter, C_NULL, n - 1) # 0-based
+  else
+      ret = ccall((:gtk_tree_model_iter_nth_child, Gtk.libgtk), Cint,
+          (Ptr{Gtk.GObject}, Ptr{Gtk.GtkTreeIter}, Ptr{Gtk.GtkTreeIter}, Cint),
+          treeModel, iter, Gtk.mutable(piter), n - 1) # 0-based
+  end
+    ret != 0
+end
 
 function model(tree_view::Gtk.GtkTreeView)
     return convert(Gtk.GtkTreeStore,

--- a/src/GtkExtensions.jl
+++ b/src/GtkExtensions.jl
@@ -24,7 +24,7 @@ get_default_mod_mask() = ccall((:gtk_accelerator_get_default_mod_mask , libgtk),
 
 grab_focus(w::Gtk.GObject) = ccall((:gtk_widget_grab_focus , libgtk),Void,(Ptr{Gtk.GObject},),w)#this should work?
 grab_focus(w::Gtk.GtkWindow) = ccall((:gtk_widget_grab_focus , libgtk),Void,(Ptr{Gtk.GObject},),w)
-hide(w::Gtk.GtkWidget) = ccall((:gtk_widget_hide , libgtk),Void,(Ptr{Gtk.GObject},),w)
+
 
 
 ## TextIters

--- a/src/GtkExtensions.jl
+++ b/src/GtkExtensions.jl
@@ -381,6 +381,12 @@ function model(tree_view::Gtk.GtkTreeView)
                   (Ptr{Gtk.GObject},),
                   tree_view))
 end
+#GtkDialog
+function response(dialog::Gtk.GtkDialog, response::Integer)
+    ccall((:gtk_dialog_response, Gtk.libgtk), Void,
+       (Ptr{Gtk.GObject}, Cint),
+       dialog,response)
 
+end
 
 #end#module

--- a/src/GtkExtensions.jl
+++ b/src/GtkExtensions.jl
@@ -24,6 +24,8 @@ get_default_mod_mask() = ccall((:gtk_accelerator_get_default_mod_mask , libgtk),
 
 grab_focus(w::Gtk.GObject) = ccall((:gtk_widget_grab_focus , libgtk),Void,(Ptr{Gtk.GObject},),w)#this should work?
 grab_focus(w::Gtk.GtkWindow) = ccall((:gtk_widget_grab_focus , libgtk),Void,(Ptr{Gtk.GObject},),w)
+hide(w::Gtk.GtkWidget) = ccall((:gtk_widget_hide , libgtk),Void,(Ptr{Gtk.GObject},),w)
+
 
 ## TextIters
 
@@ -200,6 +202,23 @@ get_tab(notebook::Gtk.GtkNotebook,page_num::Int) = convert(Gtk.GtkWidget,ccall((
 
 set_tab_label_text(notebook::Gtk.GtkNotebook,child,tab_text) = ccall((:gtk_notebook_set_tab_label_text,Gtk.libgtk),Void,(Ptr{Gtk.GObject},
 Ptr{Gtk.GObject},Ptr{UInt8}),notebook,child,tab_text)
+popup_disble(notebook::Gtk.GtkNotebook) = ccall((:gtk_notebook_popup_disable ,Gtk.libgtk),
+      Void,
+      (Ptr{Gtk.GObject},),
+      notebook)
+function tab_num(notebook::Gtk.GtkNotebook,widget)
+    return ccall((:gtk_notebook_page_num,Gtk.libgtk),
+          Cint,
+          (Ptr{Gtk.GObject},Ptr{Gtk.GObject}),
+          notebook,widget) +1
+end
+import Base.insert!
+function insert!(w::Gtk.GtkNotebook, position::Integer, x::Union{Gtk.GtkWidget,Gtk.AbstractStringLike}, label::Union{Gtk.GtkWidget,Gtk.AbstractStringLike}, menu::Gtk.GtkWidget)
+    ccall((:gtk_notebook_insert_page_menu,libgtk), Cint,
+        (Ptr{GObject}, Ptr{Gtk.GObject}, Ptr{Gtk.GObject},Ptr{Gtk.GObject}, Cint),
+        w, x, label, menu,position-1)+1
+    w
+end
 
 ## entry
 
@@ -359,5 +378,9 @@ function model(tree_view::Gtk.GtkTreeView)
                   (Ptr{Gtk.GObject},),
                   tree_view))
 end
+#GtkEventBox
+Gtk.@gtktype GtkEventBox
+GtkEventBoxLeaf() =  GtkEventBoxLeaf(ccall((:gtk_event_box_new ,libgtk), Ptr{GObject},
+        ()))
 
 #end#module

--- a/src/Project.jl
+++ b/src/Project.jl
@@ -46,7 +46,9 @@ function load(w::Project)
         w.path = pwd()
         return
     end    
+	println( joinpath(HOMEDIR,"config","project"))
     j = JSON.parsefile( joinpath(HOMEDIR,"config","project") )
+
     w.path = j["path"]
     w.files = j["files"]
     w.scroll_position = j["scroll_position"]


### PR DESCRIPTION
Fixed:
[](url)
- Incorrect usage of GtkDialog and GtkBuilder. [source](http://stackoverflow.com/questions/4657344/how-to-repeatedly-show-a-dialog-with-pygtk-gtkbuilder): The dialog
  must not be destroyed, otherwise gtkbuilder will return the destroyed dialog in the next time is requested. Now the dialog is hidden and reconfigured every time it displayed.
- Don't open a file multiple times. When a file is already opened makes it the current tab
- Correct label caption when a file is modified
- Ordered insert of files and folders
- Fixed parameter name was ursor_pos insted of cursor_pos in path_dialog_filename_inserted_text
